### PR TITLE
Updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 Boilerplate for creating Custom Extensions for [XSplit Broadcaster](https://www.xsplit.com/#broadcaster)
 written in **Typescript** using [Visual Studio Code](https://code.visualstudio.com).
 
-**Important**: until [PR #188](https://github.com/xjsframework/xjs/pull/188) is merged & published,
-you have to manually add a line `"types": "src/index.ts"` in the package.json
-of module `xjs-framework` for VSCode Intellisense to work.
-
 
 -------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postcss-cssnext": "3.1.0",
     "postcss-loader": "2.0.10",
     "source-map-loader": "0.2.3",
-    "style-loader": "0.20.0",
+    "style-loader": "0.20.1",
     "ts-node": "4.1.0",
     "typescript": "2.6.2",
     "url-loader": "0.6.2",
@@ -40,6 +40,6 @@
     "webpack": "3.10.0",
     "webpack-dev-server": "2.11.1",
     "webpack-subresource-integrity": "1.0.3",
-    "xjs-framework": "2.6.0"
+    "xjs-framework": "2.7.0"
   }
 }


### PR DESCRIPTION
The `types` line [has been added](https://github.com/xjsframework/xjs/pull/188) to `xjs-framework` :tada:

However, I have to keep Typescript at `2.6.2` instead of the newer `2.7.1` for now because there are parts of dependency `xjs-framework` that seem incompatible with latest Typescript: at-loader outputs a lot of `Child process failed to process the request:  Error: Debug Failure.` errors whereas all other boilerplates work fine with 2.7.1, so Typescript itself isn't the core issue.
